### PR TITLE
Remove Arc<Mutex<D>>

### DIFF
--- a/src/bin/block_circuit.rs
+++ b/src/bin/block_circuit.rs
@@ -22,8 +22,9 @@ use intmax_zkp_core::{
     },
     sparse_merkle_tree::{
         goldilocks_poseidon::{
-            GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree, NodeDataMemory,
-            PoseidonSparseMerkleTree, WrappedHashOut,
+            GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree,
+            LayeredLayeredPoseidonSparseMerkleTreeMemory, NodeDataMemory, PoseidonSparseMerkleTree,
+            PoseidonSparseMerkleTreeMemory, WrappedHashOut,
         },
         proof::SparseMerkleInclusionProof,
     },
@@ -58,7 +59,7 @@ fn main() {
     const N_BLOCKS: usize = 2;
 
     let mut world_state_tree =
-        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
+        PoseidonSparseMerkleTreeMemory::new(Default::default(), Default::default());
 
     let merge_and_purge_circuit = make_user_proof_circuit::<
         F,
@@ -89,11 +90,11 @@ fn main() {
     let sender1_account = private_key_to_account(sender1_private_key);
     let sender1_address = sender1_account.address.0;
 
-    let mut sender1_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
-        LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
+    let mut sender1_user_asset_tree =
+        LayeredLayeredPoseidonSparseMerkleTreeMemory::new(Default::default(), Default::default());
 
-    let mut sender1_tx_diff_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
-        LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
+    let mut sender1_tx_diff_tree =
+        LayeredLayeredPoseidonSparseMerkleTreeMemory::new(Default::default(), Default::default());
 
     let key1 = (
         GoldilocksHashOut::from_u128(12),
@@ -132,7 +133,7 @@ fn main() {
     world_state_tree
         .set(
             sender1_account.address.0.into(),
-            sender1_user_asset_tree.get_root(),
+            sender1_user_asset_tree.get_root().unwrap(),
         )
         .unwrap();
 
@@ -170,7 +171,7 @@ fn main() {
         PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
 
     let mut sender2_tx_diff_tree =
-        LayeredLayeredPoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
+        LayeredLayeredPoseidonSparseMerkleTreeMemory::new(node_data.clone(), Default::default());
 
     let mut deposit_sender2_tree =
         LayeredLayeredPoseidonSparseMerkleTree::new(node_data, Default::default());
@@ -182,8 +183,7 @@ fn main() {
         .set(sender2_address.into(), key2.1, key2.2, value2)
         .unwrap();
 
-    let deposit_sender2_tree: PoseidonSparseMerkleTree<NodeDataMemory> =
-        deposit_sender2_tree.into();
+    let deposit_sender2_tree: PoseidonSparseMerkleTreeMemory = deposit_sender2_tree.into();
 
     let merge_inclusion_proof2 = deposit_sender2_tree.find(&sender2_address.into()).unwrap();
 
@@ -229,10 +229,13 @@ fn main() {
     };
 
     world_state_tree
-        .set(sender2_address.into(), sender2_user_asset_tree.get_root())
+        .set(
+            sender2_address.into(),
+            sender2_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
-    let mut sender2_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender2_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         sender2_user_asset_tree.into();
     let proof1 = sender2_user_asset_tree
         .set(deposit_merge_key, key2.1, key2.2, zero)
@@ -327,13 +330,19 @@ fn main() {
     let mut user_tx_proofs = vec![];
 
     let sender1_world_state_process_proof = world_state_tree
-        .set(sender1_address.into(), sender1_user_asset_tree.get_root())
+        .set(
+            sender1_address.into(),
+            sender1_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
     // dbg!(serde_json::to_string(&sender1_world_state_process_proof).unwrap());
 
     let sender2_world_state_process_proof = world_state_tree
-        .set(sender2_address.into(), sender2_user_asset_tree.get_root())
+        .set(
+            sender2_address.into(),
+            sender2_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
     world_state_process_proofs.push(sender1_world_state_process_proof);
@@ -347,7 +356,7 @@ fn main() {
     zkdsa_circuit.targets.set_witness(
         &mut pw,
         sender1_account.private_key,
-        *world_state_tree.get_root(),
+        *world_state_tree.get_root().unwrap(),
     );
 
     println!("start proving: sender1_received_signature");
@@ -362,7 +371,7 @@ fn main() {
     zkdsa_circuit.targets.set_witness(
         &mut pw,
         sender2_account.private_key,
-        *world_state_tree.get_root(),
+        *world_state_tree.get_root().unwrap(),
     );
 
     println!("start proving: sender2_received_signature");
@@ -409,7 +418,7 @@ fn main() {
         (Some(sender2_received_signature), sender2_tx_proof),
     ];
 
-    let mut latest_account_tree: PoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut latest_account_tree: PoseidonSparseMerkleTreeMemory =
         PoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
     // NOTICE: merge proof の中に deposit が混ざっていると, revert proof がうまく出せない場合がある.
@@ -470,7 +479,7 @@ fn main() {
         amount: GoldilocksField::from_noncanonical_u64(1),
     }];
 
-    let mut deposit_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut deposit_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
     let deposit_process_proofs = deposit_list
         .iter()

--- a/src/bin/block_circuit.rs
+++ b/src/bin/block_circuit.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::time::Instant;
 
 use plonky2::{
     field::{
@@ -60,10 +57,8 @@ fn main() {
     const N_TXS: usize = 2usize.pow(N_LOG_TXS as u32);
     const N_BLOCKS: usize = 2;
 
-    let mut world_state_tree = PoseidonSparseMerkleTree::new(
-        Arc::new(Mutex::new(NodeDataMemory::default())),
-        Default::default(),
-    );
+    let mut world_state_tree =
+        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
 
     let merge_and_purge_circuit = make_user_proof_circuit::<
         F,
@@ -170,7 +165,7 @@ fn main() {
     let sender2_account = private_key_to_account(sender2_private_key);
     let sender2_address = sender2_account.address.0;
 
-    let node_data = Arc::new(Mutex::new(NodeDataMemory::default()));
+    let node_data = NodeDataMemory::default();
     let mut sender2_user_asset_tree =
         PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
 

--- a/src/bin/verify_smt_process.rs
+++ b/src/bin/verify_smt_process.rs
@@ -13,7 +13,7 @@ use plonky2::{
 
 use intmax_zkp_core::sparse_merkle_tree::{
     gadgets::process::process_smt::SparseMerkleProcessProofTarget,
-    goldilocks_poseidon::{GoldilocksHashOut, NodeDataMemory, PoseidonSparseMerkleTree},
+    goldilocks_poseidon::{GoldilocksHashOut, PoseidonSparseMerkleTreeMemory},
 };
 
 const D: usize = 2; // extension degree
@@ -42,8 +42,7 @@ fn main() {
 }
 
 fn benchmark() {
-    let mut tree: PoseidonSparseMerkleTree<NodeDataMemory> =
-        PoseidonSparseMerkleTree::new(Default::default(), Default::default());
+    let mut tree = PoseidonSparseMerkleTreeMemory::new(Default::default(), Default::default());
     let key1 = GoldilocksHashOut::from_u128(1);
     let value1 = GoldilocksHashOut::from_u128(2);
 

--- a/src/rollup/gadgets/approval_block/mod.rs
+++ b/src/rollup/gadgets/approval_block/mod.rs
@@ -375,8 +375,9 @@ fn test_approval_block() {
         merkle_tree::tree::get_merkle_proof,
         sparse_merkle_tree::{
             goldilocks_poseidon::{
-                GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree, NodeDataMemory,
-                PoseidonSparseMerkleTree, WrappedHashOut,
+                GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree,
+                LayeredLayeredPoseidonSparseMerkleTreeMemory, NodeDataMemory,
+                PoseidonSparseMerkleTree, PoseidonSparseMerkleTreeMemory, WrappedHashOut,
             },
             proof::SparseMerkleInclusionProof,
         },
@@ -404,7 +405,7 @@ fn test_approval_block() {
     const N_TXS: usize = 2usize.pow(N_LOG_TXS as u32);
 
     let mut world_state_tree =
-        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
+        PoseidonSparseMerkleTreeMemory::new(Default::default(), Default::default());
 
     let merge_and_purge_circuit = make_user_proof_circuit::<
         F,
@@ -435,10 +436,10 @@ fn test_approval_block() {
     let sender1_account = private_key_to_account(sender1_private_key);
     let sender1_address = sender1_account.address.0;
 
-    let mut sender1_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender1_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
-    let mut sender1_tx_diff_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender1_tx_diff_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
     let key1 = (
@@ -478,7 +479,7 @@ fn test_approval_block() {
     world_state_tree
         .set(
             sender1_account.address.0.into(),
-            sender1_user_asset_tree.get_root(),
+            sender1_user_asset_tree.get_root().unwrap(),
         )
         .unwrap();
 
@@ -516,7 +517,7 @@ fn test_approval_block() {
         PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
 
     let mut sender2_tx_diff_tree =
-        LayeredLayeredPoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
+        LayeredLayeredPoseidonSparseMerkleTreeMemory::new(node_data.clone(), Default::default());
 
     let mut deposit_sender2_tree =
         LayeredLayeredPoseidonSparseMerkleTree::new(node_data, Default::default());
@@ -528,8 +529,7 @@ fn test_approval_block() {
         .set(sender2_address.into(), key2.1, key2.2, value2)
         .unwrap();
 
-    let deposit_sender2_tree: PoseidonSparseMerkleTree<NodeDataMemory> =
-        deposit_sender2_tree.into();
+    let deposit_sender2_tree: PoseidonSparseMerkleTreeMemory = deposit_sender2_tree.into();
 
     let merge_inclusion_proof2 = deposit_sender2_tree.find(&sender2_address.into()).unwrap();
 
@@ -572,10 +572,13 @@ fn test_approval_block() {
     };
 
     world_state_tree
-        .set(sender2_address.into(), sender2_user_asset_tree.get_root())
+        .set(
+            sender2_address.into(),
+            sender2_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
-    let mut sender2_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender2_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         sender2_user_asset_tree.into();
     let proof1 = sender2_user_asset_tree
         .set(deposit_merge_key, key2.1, key2.2, zero)
@@ -670,13 +673,19 @@ fn test_approval_block() {
     let mut user_tx_proofs = vec![];
 
     let sender1_world_state_process_proof = world_state_tree
-        .set(sender1_address.into(), sender1_user_asset_tree.get_root())
+        .set(
+            sender1_address.into(),
+            sender1_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
     // dbg!(serde_json::to_string(&sender1_world_state_process_proof).unwrap());
 
     let sender2_world_state_process_proof = world_state_tree
-        .set(sender2_address.into(), sender2_user_asset_tree.get_root())
+        .set(
+            sender2_address.into(),
+            sender2_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
     world_state_process_proofs.push(sender1_world_state_process_proof);
@@ -690,7 +699,7 @@ fn test_approval_block() {
     zkdsa_circuit.targets.set_witness(
         &mut pw,
         sender1_account.private_key,
-        *world_state_tree.get_root(),
+        *world_state_tree.get_root().unwrap(),
     );
 
     println!("start proving: sender1_received_signature");
@@ -705,7 +714,7 @@ fn test_approval_block() {
     zkdsa_circuit.targets.set_witness(
         &mut pw,
         sender2_account.private_key,
-        *world_state_tree.get_root(),
+        *world_state_tree.get_root().unwrap(),
     );
 
     println!("start proving: sender2_received_signature");
@@ -740,7 +749,7 @@ fn test_approval_block() {
         (Some(sender2_received_signature), sender2_tx_proof),
     ];
 
-    let mut latest_account_tree: PoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut latest_account_tree: PoseidonSparseMerkleTreeMemory =
         PoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
     // NOTICE: merge proof の中に deposit が混ざっていると, revert proof がうまく出せない場合がある.

--- a/src/rollup/gadgets/approval_block/mod.rs
+++ b/src/rollup/gadgets/approval_block/mod.rs
@@ -358,10 +358,7 @@ pub fn verify_valid_approval_block<
 
 #[test]
 fn test_approval_block() {
-    use std::{
-        sync::{Arc, Mutex},
-        time::Instant,
-    };
+    use std::time::Instant;
 
     use plonky2::{
         field::{goldilocks_field::GoldilocksField, types::Field},
@@ -406,10 +403,8 @@ fn test_approval_block() {
     const N_MERGES: usize = 2;
     const N_TXS: usize = 2usize.pow(N_LOG_TXS as u32);
 
-    let mut world_state_tree = PoseidonSparseMerkleTree::new(
-        Arc::new(Mutex::new(NodeDataMemory::default())),
-        Default::default(),
-    );
+    let mut world_state_tree =
+        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
 
     let merge_and_purge_circuit = make_user_proof_circuit::<
         F,
@@ -516,7 +511,7 @@ fn test_approval_block() {
     let sender2_account = private_key_to_account(sender2_private_key);
     let sender2_address = sender2_account.address.0;
 
-    let node_data = Arc::new(Mutex::new(NodeDataMemory::default()));
+    let node_data = NodeDataMemory::default();
     let mut sender2_user_asset_tree =
         PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
 

--- a/src/rollup/gadgets/deposit_block/mod.rs
+++ b/src/rollup/gadgets/deposit_block/mod.rs
@@ -272,8 +272,9 @@ fn test_deposit_block() {
         rollup::gadgets::deposit_block::DepositInfo,
         sparse_merkle_tree::{
             goldilocks_poseidon::{
-                GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree, NodeDataMemory,
-                PoseidonSparseMerkleTree, WrappedHashOut,
+                GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree,
+                LayeredLayeredPoseidonSparseMerkleTreeMemory, NodeDataMemory,
+                PoseidonSparseMerkleTree, PoseidonSparseMerkleTreeMemory, WrappedHashOut,
             },
             proof::SparseMerkleInclusionProof,
         },
@@ -305,7 +306,7 @@ fn test_deposit_block() {
     const N_MERGES: usize = 2;
 
     let mut world_state_tree =
-        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
+        PoseidonSparseMerkleTreeMemory::new(NodeDataMemory::default(), Default::default());
 
     let merge_and_purge_circuit = make_user_proof_circuit::<
         F,
@@ -336,10 +337,10 @@ fn test_deposit_block() {
     let sender1_account = private_key_to_account(sender1_private_key);
     let sender1_address = sender1_account.address.0;
 
-    let mut sender1_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender1_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
-    let mut sender1_tx_diff_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender1_tx_diff_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
     let key1 = (
@@ -379,7 +380,7 @@ fn test_deposit_block() {
     world_state_tree
         .set(
             sender1_account.address.0.into(),
-            sender1_user_asset_tree.get_root(),
+            sender1_user_asset_tree.get_root().unwrap(),
         )
         .unwrap();
 
@@ -417,7 +418,7 @@ fn test_deposit_block() {
         PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
 
     let mut sender2_tx_diff_tree =
-        LayeredLayeredPoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
+        LayeredLayeredPoseidonSparseMerkleTreeMemory::new(node_data.clone(), Default::default());
 
     let mut deposit_sender2_tree =
         LayeredLayeredPoseidonSparseMerkleTree::new(node_data, Default::default());
@@ -429,8 +430,7 @@ fn test_deposit_block() {
         .set(sender2_address.into(), key2.1, key2.2, value2)
         .unwrap();
 
-    let deposit_sender2_tree: PoseidonSparseMerkleTree<NodeDataMemory> =
-        deposit_sender2_tree.into();
+    let deposit_sender2_tree: PoseidonSparseMerkleTreeMemory = deposit_sender2_tree.into();
 
     let merge_inclusion_proof2 = deposit_sender2_tree.find(&sender2_address.into()).unwrap();
 
@@ -473,10 +473,13 @@ fn test_deposit_block() {
     };
 
     world_state_tree
-        .set(sender2_address.into(), sender2_user_asset_tree.get_root())
+        .set(
+            sender2_address.into(),
+            sender2_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
-    let mut sender2_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender2_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         sender2_user_asset_tree.into();
     let proof1 = sender2_user_asset_tree
         .set(deposit_merge_key, key2.1, key2.2, zero)
@@ -571,13 +574,19 @@ fn test_deposit_block() {
     let mut user_tx_proofs = vec![];
 
     let sender1_world_state_process_proof = world_state_tree
-        .set(sender1_address.into(), sender1_user_asset_tree.get_root())
+        .set(
+            sender1_address.into(),
+            sender1_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
     // dbg!(serde_json::to_string(&sender1_world_state_process_proof).unwrap());
 
     let sender2_world_state_process_proof = world_state_tree
-        .set(sender2_address.into(), sender2_user_asset_tree.get_root())
+        .set(
+            sender2_address.into(),
+            sender2_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
     world_state_process_proofs.push(sender1_world_state_process_proof);
@@ -591,7 +600,7 @@ fn test_deposit_block() {
     zkdsa_circuit.targets.set_witness(
         &mut pw,
         sender1_account.private_key,
-        *world_state_tree.get_root(),
+        *world_state_tree.get_root().unwrap(),
     );
 
     println!("start proving: sender1_received_signature");
@@ -606,7 +615,7 @@ fn test_deposit_block() {
     zkdsa_circuit.targets.set_witness(
         &mut pw,
         sender2_account.private_key,
-        *world_state_tree.get_root(),
+        *world_state_tree.get_root().unwrap(),
     );
 
     println!("start proving: sender2_received_signature");
@@ -638,7 +647,7 @@ fn test_deposit_block() {
         (Some(sender2_received_signature), sender2_tx_proof),
     ];
 
-    let mut latest_account_tree: PoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut latest_account_tree: PoseidonSparseMerkleTreeMemory =
         PoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
     // NOTICE: merge proof の中に deposit が混ざっていると, revert proof がうまく出せない場合がある.
@@ -684,7 +693,7 @@ fn test_deposit_block() {
         amount: GoldilocksField::from_noncanonical_u64(1),
     }];
 
-    let mut deposit_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut deposit_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
     let deposit_process_proofs = deposit_list
         .iter()

--- a/src/rollup/gadgets/deposit_block/mod.rs
+++ b/src/rollup/gadgets/deposit_block/mod.rs
@@ -251,10 +251,7 @@ pub fn calc_deposit_digest<
 
 #[test]
 fn test_deposit_block() {
-    use std::{
-        sync::{Arc, Mutex},
-        time::Instant,
-    };
+    use std::time::Instant;
 
     use plonky2::{
         field::{
@@ -307,10 +304,8 @@ fn test_deposit_block() {
     const N_DIFFS: usize = 2;
     const N_MERGES: usize = 2;
 
-    let mut world_state_tree = PoseidonSparseMerkleTree::new(
-        Arc::new(Mutex::new(NodeDataMemory::default())),
-        Default::default(),
-    );
+    let mut world_state_tree =
+        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
 
     let merge_and_purge_circuit = make_user_proof_circuit::<
         F,
@@ -417,7 +412,7 @@ fn test_deposit_block() {
     let sender2_account = private_key_to_account(sender2_private_key);
     let sender2_address = sender2_account.address.0;
 
-    let node_data = Arc::new(Mutex::new(NodeDataMemory::default()));
+    let node_data = NodeDataMemory::default();
     let mut sender2_user_asset_tree =
         PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
 

--- a/src/rollup/gadgets/proposal_block/mod.rs
+++ b/src/rollup/gadgets/proposal_block/mod.rs
@@ -256,8 +256,9 @@ fn test_proposal_block() {
         merkle_tree::tree::get_merkle_proof,
         sparse_merkle_tree::{
             goldilocks_poseidon::{
-                GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree, NodeDataMemory,
-                PoseidonSparseMerkleTree, WrappedHashOut,
+                GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree,
+                LayeredLayeredPoseidonSparseMerkleTreeMemory, NodeDataMemory,
+                PoseidonSparseMerkleTree, PoseidonSparseMerkleTreeMemory, WrappedHashOut,
             },
             proof::SparseMerkleInclusionProof,
         },
@@ -285,7 +286,7 @@ fn test_proposal_block() {
     const N_TXS: usize = 2usize.pow(N_LOG_TXS as u32);
 
     let mut world_state_tree =
-        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
+        PoseidonSparseMerkleTreeMemory::new(NodeDataMemory::default(), Default::default());
 
     let merge_and_purge_circuit = make_user_proof_circuit::<
         F,
@@ -316,10 +317,10 @@ fn test_proposal_block() {
     let sender1_account = private_key_to_account(sender1_private_key);
     let sender1_address = sender1_account.address.0;
 
-    let mut sender1_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender1_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
-    let mut sender1_tx_diff_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender1_tx_diff_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         LayeredLayeredPoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
     let key1 = (
@@ -359,7 +360,7 @@ fn test_proposal_block() {
     world_state_tree
         .set(
             sender1_account.address.0.into(),
-            sender1_user_asset_tree.get_root(),
+            sender1_user_asset_tree.get_root().unwrap(),
         )
         .unwrap();
 
@@ -397,7 +398,7 @@ fn test_proposal_block() {
         PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
 
     let mut sender2_tx_diff_tree =
-        LayeredLayeredPoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
+        LayeredLayeredPoseidonSparseMerkleTreeMemory::new(node_data.clone(), Default::default());
 
     let mut deposit_sender2_tree =
         LayeredLayeredPoseidonSparseMerkleTree::new(node_data, Default::default());
@@ -409,8 +410,7 @@ fn test_proposal_block() {
         .set(sender2_address.into(), key2.1, key2.2, value2)
         .unwrap();
 
-    let deposit_sender2_tree: PoseidonSparseMerkleTree<NodeDataMemory> =
-        deposit_sender2_tree.into();
+    let deposit_sender2_tree: PoseidonSparseMerkleTreeMemory = deposit_sender2_tree.into();
 
     let merge_inclusion_proof2 = deposit_sender2_tree.find(&sender2_address.into()).unwrap();
 
@@ -453,10 +453,13 @@ fn test_proposal_block() {
     };
 
     world_state_tree
-        .set(sender2_address.into(), sender2_user_asset_tree.get_root())
+        .set(
+            sender2_address.into(),
+            sender2_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
-    let mut sender2_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut sender2_user_asset_tree: LayeredLayeredPoseidonSparseMerkleTreeMemory =
         sender2_user_asset_tree.into();
     let proof1 = sender2_user_asset_tree
         .set(deposit_merge_key, key2.1, key2.2, zero)
@@ -551,13 +554,19 @@ fn test_proposal_block() {
     let mut user_tx_proofs = vec![];
 
     let sender1_world_state_process_proof = world_state_tree
-        .set(sender1_address.into(), sender1_user_asset_tree.get_root())
+        .set(
+            sender1_address.into(),
+            sender1_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
     // dbg!(serde_json::to_string(&sender1_world_state_process_proof).unwrap());
 
     let sender2_world_state_process_proof = world_state_tree
-        .set(sender2_address.into(), sender2_user_asset_tree.get_root())
+        .set(
+            sender2_address.into(),
+            sender2_user_asset_tree.get_root().unwrap(),
+        )
         .unwrap();
 
     world_state_process_proofs.push(sender1_world_state_process_proof);
@@ -571,7 +580,7 @@ fn test_proposal_block() {
     zkdsa_circuit.targets.set_witness(
         &mut pw,
         sender1_account.private_key,
-        *world_state_tree.get_root(),
+        *world_state_tree.get_root().unwrap(),
     );
 
     println!("start proving: sender1_received_signature");
@@ -586,7 +595,7 @@ fn test_proposal_block() {
     zkdsa_circuit.targets.set_witness(
         &mut pw,
         sender2_account.private_key,
-        *world_state_tree.get_root(),
+        *world_state_tree.get_root().unwrap(),
     );
 
     println!("start proving: sender2_received_signature");
@@ -611,7 +620,7 @@ fn test_proposal_block() {
         (Some(sender2_received_signature), sender2_tx_proof),
     ];
 
-    let mut latest_account_tree: PoseidonSparseMerkleTree<NodeDataMemory> =
+    let mut latest_account_tree: PoseidonSparseMerkleTreeMemory =
         PoseidonSparseMerkleTree::new(Default::default(), Default::default());
 
     // NOTICE: merge proof の中に deposit が混ざっていると, revert proof がうまく出せない場合がある.

--- a/src/rollup/gadgets/proposal_block/mod.rs
+++ b/src/rollup/gadgets/proposal_block/mod.rs
@@ -239,10 +239,7 @@ pub fn verify_valid_proposal_block<
 
 #[test]
 fn test_proposal_block() {
-    use std::{
-        sync::{Arc, Mutex},
-        time::Instant,
-    };
+    use std::time::Instant;
 
     use plonky2::{
         field::{goldilocks_field::GoldilocksField, types::Field},
@@ -287,10 +284,8 @@ fn test_proposal_block() {
     const N_MERGES: usize = 2;
     const N_TXS: usize = 2usize.pow(N_LOG_TXS as u32);
 
-    let mut world_state_tree = PoseidonSparseMerkleTree::new(
-        Arc::new(Mutex::new(NodeDataMemory::default())),
-        Default::default(),
-    );
+    let mut world_state_tree =
+        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
 
     let merge_and_purge_circuit = make_user_proof_circuit::<
         F,
@@ -397,7 +392,7 @@ fn test_proposal_block() {
     let sender2_account = private_key_to_account(sender2_private_key);
     let sender2_address = sender2_account.address.0;
 
-    let node_data = Arc::new(Mutex::new(NodeDataMemory::default()));
+    let node_data = NodeDataMemory::default();
     let mut sender2_user_asset_tree =
         PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
 

--- a/src/sparse_merkle_tree/gadgets/process/mod.rs
+++ b/src/sparse_merkle_tree/gadgets/process/mod.rs
@@ -16,7 +16,7 @@ fn test_verify_process_proof_by_plonky2() {
 
     use super::super::{
         gadgets::process::process_smt::SparseMerkleProcessProofTarget,
-        goldilocks_poseidon::{GoldilocksHashOut, NodeDataMemory, PoseidonSparseMerkleTree},
+        goldilocks_poseidon::{GoldilocksHashOut, PoseidonSparseMerkleTreeMemory},
     };
 
     const D: usize = 2; // extension degree
@@ -26,8 +26,7 @@ fn test_verify_process_proof_by_plonky2() {
     // type F = GoldilocksField;
     const N_LEVELS: usize = 16;
 
-    let mut tree: PoseidonSparseMerkleTree<NodeDataMemory> =
-        PoseidonSparseMerkleTree::new(Default::default(), Default::default());
+    let mut tree = PoseidonSparseMerkleTreeMemory::new(Default::default(), Default::default());
     let key1 = GoldilocksHashOut::from_u128(1);
     let value1 = GoldilocksHashOut::from_u128(2);
 

--- a/src/sparse_merkle_tree/gadgets/verify/mod.rs
+++ b/src/sparse_merkle_tree/gadgets/verify/mod.rs
@@ -11,7 +11,7 @@ fn test_verify_inclusion_proof_by_plonky2() {
 
     use super::super::{
         gadgets::verify::verify_smt::SparseMerkleInclusionProofTarget,
-        goldilocks_poseidon::{GoldilocksHashOut, NodeDataMemory, PoseidonSparseMerkleTree},
+        goldilocks_poseidon::{GoldilocksHashOut, PoseidonSparseMerkleTreeMemory},
     };
 
     const D: usize = 2; // extension degree
@@ -21,8 +21,7 @@ fn test_verify_inclusion_proof_by_plonky2() {
     // type F = GoldilocksField;
     const N_LEVELS: usize = 16;
 
-    let mut tree: PoseidonSparseMerkleTree<NodeDataMemory> =
-        PoseidonSparseMerkleTree::new(Default::default(), Default::default());
+    let mut tree = PoseidonSparseMerkleTreeMemory::new(Default::default(), Default::default());
     let key1 = GoldilocksHashOut::from_u128(1);
     let value1 = GoldilocksHashOut::from_u128(2);
     let key2 = GoldilocksHashOut::from_u128(12);

--- a/src/sparse_merkle_tree/goldilocks_poseidon/mod.rs
+++ b/src/sparse_merkle_tree/goldilocks_poseidon/mod.rs
@@ -122,6 +122,29 @@ impl RootData<I> for RootDataMemory {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct RootDataTmp(pub I);
+
+impl From<I> for RootDataTmp {
+    fn from(value: I) -> Self {
+        Self(value)
+    }
+}
+
+impl RootData<I> for RootDataTmp {
+    type Error = anyhow::Error;
+
+    fn get(&self) -> Result<I, Self::Error> {
+        Ok(self.0)
+    }
+
+    fn set(&mut self, root: I) -> Result<(), Self::Error> {
+        let _ = std::mem::replace(self, Self(root));
+
+        Ok(())
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PoseidonNodeHash {}
 
@@ -150,9 +173,18 @@ impl NodeHash<K, V, I> for PoseidonNodeHash {
     }
 }
 
-pub type PoseidonSparseMerkleTree<D> = SparseMerkleTree<K, V, I, PoseidonNodeHash, D>;
+pub type PoseidonSparseMerkleTree<D, R> = SparseMerkleTree<K, V, I, PoseidonNodeHash, D, R>;
 
-pub type LayeredPoseidonSparseMerkleTree<D> = LayeredSparseMerkleTree<K, V, I, PoseidonNodeHash, D>;
+pub type LayeredPoseidonSparseMerkleTree<D, R> =
+    LayeredSparseMerkleTree<K, V, I, PoseidonNodeHash, D, R>;
 
-pub type LayeredLayeredPoseidonSparseMerkleTree<D> =
-    LayeredLayeredSparseMerkleTree<K, V, I, PoseidonNodeHash, D>;
+pub type LayeredLayeredPoseidonSparseMerkleTree<D, R> =
+    LayeredLayeredSparseMerkleTree<K, V, I, PoseidonNodeHash, D, R>;
+
+pub type PoseidonSparseMerkleTreeMemory = PoseidonSparseMerkleTree<NodeDataMemory, RootDataMemory>;
+
+pub type LayeredPoseidonSparseMerkleTreeMemory =
+    LayeredPoseidonSparseMerkleTree<NodeDataMemory, RootDataMemory>;
+
+pub type LayeredLayeredPoseidonSparseMerkleTreeMemory =
+    LayeredLayeredPoseidonSparseMerkleTree<NodeDataMemory, RootDataMemory>;

--- a/src/sparse_merkle_tree/layered_layered_tree.rs
+++ b/src/sparse_merkle_tree/layered_layered_tree.rs
@@ -4,6 +4,7 @@ use super::{
     node_data::NodeData,
     node_hash::NodeHash,
     proof::{SparseMerkleInclusionProof, SparseMerkleProcessProof},
+    root_data::RootData,
     tree::{
         calc_inclusion_proof, calc_process_proof, get, HashLike, KeyLike, SparseMerkleTree,
         ValueLike,
@@ -28,51 +29,57 @@ pub struct LayeredLayeredSparseMerkleTree<
     I: Sized,
     H: NodeHash<K, V, I>,
     D: NodeData<K, V, I>,
+    R: RootData<I>,
 > {
     pub nodes_db: D,
-    pub root: I,
+    pub roots_db: R,
     pub _key: std::marker::PhantomData<K>,
     pub _value: std::marker::PhantomData<V>,
+    pub _root: std::marker::PhantomData<I>,
     pub _hash: std::marker::PhantomData<H>,
 }
 
-impl<K: Sized, V: Sized, I: Sized, H: NodeHash<K, V, I>, D: NodeData<K, V, I>>
-    From<LayeredLayeredSparseMerkleTree<K, V, I, H, D>> for SparseMerkleTree<K, V, I, H, D>
+impl<K: Sized, V: Sized, I: Sized, H: NodeHash<K, V, I>, D: NodeData<K, V, I>, R: RootData<I>>
+    From<LayeredLayeredSparseMerkleTree<K, V, I, H, D, R>> for SparseMerkleTree<K, V, I, H, D, R>
 {
-    fn from(value: LayeredLayeredSparseMerkleTree<K, V, I, H, D>) -> Self {
+    fn from(value: LayeredLayeredSparseMerkleTree<K, V, I, H, D, R>) -> Self {
         Self {
             nodes_db: value.nodes_db,
-            root: value.root,
+            roots_db: value.roots_db,
             _key: std::marker::PhantomData,
             _value: std::marker::PhantomData,
+            _root: std::marker::PhantomData,
             _hash: std::marker::PhantomData,
         }
     }
 }
 
-impl<K: Sized, V: Sized, I: Sized, H: NodeHash<K, V, I>, D: NodeData<K, V, I>>
-    From<SparseMerkleTree<K, V, I, H, D>> for LayeredLayeredSparseMerkleTree<K, V, I, H, D>
+impl<K: Sized, V: Sized, I: Sized, H: NodeHash<K, V, I>, D: NodeData<K, V, I>, R: RootData<I>>
+    From<SparseMerkleTree<K, V, I, H, D, R>> for LayeredLayeredSparseMerkleTree<K, V, I, H, D, R>
 {
-    fn from(value: SparseMerkleTree<K, V, I, H, D>) -> Self {
+    fn from(value: SparseMerkleTree<K, V, I, H, D, R>) -> Self {
         Self {
             nodes_db: value.nodes_db,
-            root: value.root,
+            roots_db: value.roots_db,
             _key: std::marker::PhantomData,
             _value: std::marker::PhantomData,
+            _root: std::marker::PhantomData,
             _hash: std::marker::PhantomData,
         }
     }
 }
 
-impl<K: Sized, V: Sized, I: Sized, H: NodeHash<K, V, I>, D: NodeData<K, V, I>>
-    LayeredLayeredSparseMerkleTree<K, V, I, H, D>
+impl<K: Sized, V: Sized, I: Sized, H: NodeHash<K, V, I>, D: NodeData<K, V, I>, R: RootData<I>>
+    LayeredLayeredSparseMerkleTree<K, V, I, H, D, R>
 {
-    pub fn new(nodes_db: D, root_hash: I) -> Self {
+    pub fn new(nodes_db: D, roots_db: R) -> Self {
         Self {
             nodes_db,
-            root: root_hash,
+            roots_db,
             _key: std::marker::PhantomData,
             _value: std::marker::PhantomData,
+            _root: std::marker::PhantomData,
+
             _hash: std::marker::PhantomData,
         }
     }
@@ -84,18 +91,24 @@ impl<
         I: Sized + Default,
         H: NodeHash<K, V, I>,
         D: NodeData<K, V, I> + Default,
-    > Default for LayeredLayeredSparseMerkleTree<K, V, I, H, D>
+        R: RootData<I> + Default,
+    > Default for LayeredLayeredSparseMerkleTree<K, V, I, H, D, R>
 {
     fn default() -> Self {
         Self::new(Default::default(), Default::default())
     }
 }
 
-impl<K: KeyLike, I: ValueLike + HashLike, H: NodeHash<K, I, I>, D: NodeData<K, I, I>>
-    LayeredLayeredSparseMerkleTree<K, I, I, H, D>
+impl<
+        K: KeyLike,
+        I: ValueLike + HashLike,
+        H: NodeHash<K, I, I>,
+        D: NodeData<K, I, I>,
+        R: RootData<I>,
+    > LayeredLayeredSparseMerkleTree<K, I, I, H, D, R>
 {
-    pub fn get_root(&self) -> I {
-        self.root
+    pub fn get_root(&self) -> Result<I, R::Error> {
+        self.roots_db.get()
     }
 
     pub fn change_root(&mut self, root_hash: I) -> anyhow::Result<()> {
@@ -111,7 +124,9 @@ impl<K: KeyLike, I: ValueLike + HashLike, H: NodeHash<K, I, I>, D: NodeData<K, I
             }
         }
 
-        self.root = root_hash;
+        self.roots_db
+            .set(root_hash)
+            .map_err(|err| anyhow::anyhow!("{:?}", err))?;
 
         Ok(())
     }
@@ -124,7 +139,9 @@ impl<K: KeyLike, I: ValueLike + HashLike, H: NodeHash<K, I, I>, D: NodeData<K, I
         key3: K,
         value: I,
     ) -> anyhow::Result<LayeredLayeredSparseMerkleProcessProof<K, I, I>> {
-        let layer1_root = self.get_root();
+        let layer1_root = self
+            .get_root()
+            .map_err(|err| anyhow::anyhow!("{:?}", err))?;
         let layer2_root = get::<K, I, I, H, D>(&self.nodes_db, &layer1_root, &key1)?;
         let layer3_root = get::<K, I, I, H, D>(&self.nodes_db, &layer2_root, &key2)?;
         let result3 =
@@ -142,7 +159,9 @@ impl<K: KeyLike, I: ValueLike + HashLike, H: NodeHash<K, I, I>, D: NodeData<K, I
             result2.new_root,
         )?;
 
-        self.root = result1.new_root;
+        self.roots_db
+            .set(result1.new_root)
+            .map_err(|err| anyhow::anyhow!("{:?}", err))?;
 
         Ok((result1, result2, result3))
     }
@@ -153,7 +172,9 @@ impl<K: KeyLike, I: ValueLike + HashLike, H: NodeHash<K, I, I>, D: NodeData<K, I
         key2: &K,
         key3: &K,
     ) -> anyhow::Result<LayeredLayeredSparseMerkleInclusionProof<K, I, I>> {
-        let layer1_root = self.get_root();
+        let layer1_root = self
+            .get_root()
+            .map_err(|err| anyhow::anyhow!("{:?}", err))?;
         let result1 = calc_inclusion_proof::<K, I, I, H, D>(&self.nodes_db, &layer1_root, key1)?;
         let layer2_root = if result1.found {
             result1.value

--- a/src/sparse_merkle_tree/layered_tree.rs
+++ b/src/sparse_merkle_tree/layered_tree.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::Debug,
-    sync::{Arc, Mutex},
-};
+use std::fmt::Debug;
 
 use super::{
     node_data::NodeData,
@@ -30,7 +27,7 @@ pub struct LayeredSparseMerkleTree<
     H: NodeHash<K, V, I>,
     D: NodeData<K, V, I>,
 > {
-    pub nodes_db: Arc<Mutex<D>>,
+    pub nodes_db: D,
     pub root: I,
     pub _key: std::marker::PhantomData<K>,
     pub _value: std::marker::PhantomData<V>,
@@ -68,7 +65,7 @@ impl<K: Sized, V: Sized, I: Sized, H: NodeHash<K, V, I>, D: NodeData<K, V, I>>
 impl<K: Sized, V: Sized, I: Sized, H: NodeHash<K, V, I>, D: NodeData<K, V, I>>
     LayeredSparseMerkleTree<K, V, I, H, D>
 {
-    pub fn new(nodes_db: Arc<Mutex<D>>, root_hash: I) -> Self {
+    pub fn new(nodes_db: D, root_hash: I) -> Self {
         Self {
             nodes_db,
             root: root_hash,
@@ -101,14 +98,9 @@ impl<K: KeyLike, I: ValueLike + HashLike, H: NodeHash<K, I, I>, D: NodeData<K, I
 
     pub fn change_root(&mut self, root_hash: I) -> anyhow::Result<()> {
         if !I::default().eq(&root_hash) {
-            let root_node = self
-                .nodes_db
-                .lock()
-                .map_err(|err| anyhow::anyhow!("mutex poison error: {}", err))?
-                .get(&root_hash)
-                .map_err(|err| {
-                    anyhow::anyhow!("fail to get node corresponding `root_hash`: {:?}", err)
-                })?;
+            let root_node = self.nodes_db.get(&root_hash).map_err(|err| {
+                anyhow::anyhow!("fail to get node corresponding `root_hash`: {:?}", err)
+            })?;
             if root_node.is_none() {
                 return Err(anyhow::anyhow!(
                     "the node corresponding `root_hash` does not exist"

--- a/src/sparse_merkle_tree/storage_layout/layered_layered_tree.rs
+++ b/src/sparse_merkle_tree/storage_layout/layered_layered_tree.rs
@@ -4,6 +4,8 @@ use plonky2::field::{
     types::{Field, PrimeField},
 };
 
+use crate::sparse_merkle_tree::root_data::RootData;
+
 use super::super::{
     goldilocks_poseidon::{GoldilocksHashOut, Wrapper},
     layered_layered_tree::LayeredLayeredSparseMerkleTree,
@@ -21,8 +23,8 @@ type K = GoldilocksHashOut;
 type V = GoldilocksHashOut;
 type I = GoldilocksHashOut;
 
-impl<H: NodeHash<K, V, I>, D: NodeData<K, V, I>> StorageLayout
-    for LayeredLayeredSparseMerkleTree<K, V, I, H, D>
+impl<H: NodeHash<K, V, I>, D: NodeData<K, V, I>, R: RootData<I>> StorageLayout
+    for LayeredLayeredSparseMerkleTree<K, V, I, H, D, R>
 {
     type Position = (K, K, K); // (contract_address, position)
     type VectorIndex = u128;

--- a/src/sparse_merkle_tree/storage_layout/layered_tree.rs
+++ b/src/sparse_merkle_tree/storage_layout/layered_tree.rs
@@ -4,6 +4,8 @@ use plonky2::field::{
     types::{Field, PrimeField},
 };
 
+use crate::sparse_merkle_tree::root_data::RootData;
+
 use super::super::{
     goldilocks_poseidon::{GoldilocksHashOut, Wrapper},
     layered_tree::LayeredSparseMerkleTree,
@@ -21,8 +23,8 @@ type K = GoldilocksHashOut;
 type V = GoldilocksHashOut;
 type I = GoldilocksHashOut;
 
-impl<H: NodeHash<K, V, I>, D: NodeData<K, V, I>> StorageLayout
-    for LayeredSparseMerkleTree<K, V, I, H, D>
+impl<H: NodeHash<K, V, I>, D: NodeData<K, V, I>, R: RootData<I>> StorageLayout
+    for LayeredSparseMerkleTree<K, V, I, H, D, R>
 {
     type Position = (K, K); // (contract_address, position)
     type VectorIndex = u128;

--- a/src/sparse_merkle_tree/storage_layout/tree.rs
+++ b/src/sparse_merkle_tree/storage_layout/tree.rs
@@ -8,6 +8,8 @@ use plonky2::{
     plonk::config::Hasher,
 };
 
+use crate::sparse_merkle_tree::root_data::RootData;
+
 use super::super::{
     goldilocks_poseidon::{GoldilocksHashOut, Wrapper},
     node_data::NodeData,
@@ -22,7 +24,9 @@ type K = GoldilocksHashOut;
 type V = GoldilocksHashOut;
 type I = GoldilocksHashOut;
 
-impl<H: NodeHash<K, V, I>, D: NodeData<K, V, I>> StorageLayout for SparseMerkleTree<K, V, I, H, D> {
+impl<H: NodeHash<K, V, I>, D: NodeData<K, V, I>, R: RootData<I>> StorageLayout
+    for SparseMerkleTree<K, V, I, H, D, R>
+{
     type Position = K;
     type VectorIndex = u128;
     type MappingKey = K;

--- a/src/transaction/gadgets/merge/mod.rs
+++ b/src/transaction/gadgets/merge/mod.rs
@@ -410,10 +410,7 @@ pub fn verify_user_asset_merge_proof<
 
 #[test]
 fn test_merge_proof_by_plonky2() {
-    use std::{
-        sync::{Arc, Mutex},
-        time::Instant,
-    };
+    use std::time::Instant;
 
     use plonky2::{
         field::types::Sample,
@@ -477,7 +474,7 @@ fn test_merge_proof_by_plonky2() {
     let sender2_account = private_key_to_account(sender2_private_key);
     let sender2_address = sender2_account.address.0;
 
-    let node_data = Arc::new(Mutex::new(NodeDataMemory::default()));
+    let node_data = NodeDataMemory::default();
     let mut sender2_user_asset_tree =
         PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
 

--- a/src/transaction/gadgets/merge/mod.rs
+++ b/src/transaction/gadgets/merge/mod.rs
@@ -427,7 +427,7 @@ fn test_merge_proof_by_plonky2() {
         sparse_merkle_tree::{
             goldilocks_poseidon::{
                 GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree, NodeDataMemory,
-                PoseidonSparseMerkleTree,
+                PoseidonSparseMerkleTreeMemory,
             },
             proof::SparseMerkleInclusionProof,
         },
@@ -476,7 +476,7 @@ fn test_merge_proof_by_plonky2() {
 
     let node_data = NodeDataMemory::default();
     let mut sender2_user_asset_tree =
-        PoseidonSparseMerkleTree::new(node_data.clone(), Default::default());
+        PoseidonSparseMerkleTreeMemory::new(node_data.clone(), Default::default());
 
     let mut deposit_sender2_tree =
         LayeredLayeredPoseidonSparseMerkleTree::new(node_data, Default::default());
@@ -498,8 +498,7 @@ fn test_merge_proof_by_plonky2() {
         )
         .unwrap();
 
-    let deposit_sender2_tree: PoseidonSparseMerkleTree<NodeDataMemory> =
-        deposit_sender2_tree.into();
+    let deposit_sender2_tree: PoseidonSparseMerkleTreeMemory = deposit_sender2_tree.into();
 
     let merge_inclusion_proof2 = deposit_sender2_tree.find(&sender2_address.into()).unwrap();
 

--- a/src/transaction/gadgets/purge/mod.rs
+++ b/src/transaction/gadgets/purge/mod.rs
@@ -388,8 +388,8 @@ fn test_purge_proof_by_plonky2() {
     };
 
     use crate::sparse_merkle_tree::goldilocks_poseidon::{
-        GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTree, NodeDataMemory,
-        PoseidonSparseMerkleTree,
+        GoldilocksHashOut, LayeredLayeredPoseidonSparseMerkleTreeMemory, NodeDataMemory,
+        PoseidonSparseMerkleTreeMemory,
     };
 
     const D: usize = 2;
@@ -449,18 +449,18 @@ fn test_purge_proof_by_plonky2() {
     let user_address = GoldilocksHashOut::from_u128(4);
 
     let mut world_state_tree =
-        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
+        PoseidonSparseMerkleTreeMemory::new(NodeDataMemory::default(), Default::default());
 
-    let mut user_asset_tree = LayeredLayeredPoseidonSparseMerkleTree::<NodeDataMemory>::default();
+    let mut user_asset_tree = LayeredLayeredPoseidonSparseMerkleTreeMemory::default();
 
-    let mut tx_diff_tree = LayeredLayeredPoseidonSparseMerkleTree::<NodeDataMemory>::default();
+    let mut tx_diff_tree = LayeredLayeredPoseidonSparseMerkleTreeMemory::default();
 
     let zero = GoldilocksHashOut::from_u128(0);
     user_asset_tree.set(key1.0, key1.1, key1.2, value1).unwrap();
     user_asset_tree.set(key2.0, key2.1, key2.2, value2).unwrap();
 
     world_state_tree
-        .set(user_address, user_asset_tree.get_root())
+        .set(user_address, user_asset_tree.get_root().unwrap())
         .unwrap();
 
     let proof1 = user_asset_tree.set(key2.0, key2.1, key2.2, zero).unwrap();

--- a/src/transaction/gadgets/purge/mod.rs
+++ b/src/transaction/gadgets/purge/mod.rs
@@ -376,10 +376,7 @@ pub fn verify_user_asset_purge_proof<
 
 #[test]
 fn test_purge_proof_by_plonky2() {
-    use std::{
-        sync::{Arc, Mutex},
-        time::Instant,
-    };
+    use std::time::Instant;
 
     use plonky2::{
         iop::witness::PartialWitness,
@@ -451,10 +448,8 @@ fn test_purge_proof_by_plonky2() {
 
     let user_address = GoldilocksHashOut::from_u128(4);
 
-    let mut world_state_tree = PoseidonSparseMerkleTree::new(
-        Arc::new(Mutex::new(NodeDataMemory::default())),
-        Default::default(),
-    );
+    let mut world_state_tree =
+        PoseidonSparseMerkleTree::new(NodeDataMemory::default(), Default::default());
 
     let mut user_asset_tree = LayeredLayeredPoseidonSparseMerkleTree::<NodeDataMemory>::default();
 


### PR DESCRIPTION
SMT の定義にあった `Arc<Mutex<D>>` を NodeDataMemory に押し付け、NodeData trait の別実装を書けるようにした。