### PR TITLE
Fix public key

### DIFF
--- a/src/poseidon/gadgets/mod.rs
+++ b/src/poseidon/gadgets/mod.rs
@@ -1,6 +1,10 @@
 use plonky2::{
     field::extension::Extendable,
-    hash::hash_types::{HashOutTarget, RichField},
+    hash::{
+        hash_types::{HashOutTarget, RichField},
+        hashing::SPONGE_WIDTH,
+    },
+    iop::target::Target,
     plonk::{circuit_builder::CircuitBuilder, config::AlgebraicHasher},
 };
 
@@ -9,14 +13,21 @@ pub fn poseidon_two_to_one<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, 
     x: HashOutTarget,
     y: HashOutTarget,
 ) -> HashOutTarget {
-    builder.hash_n_to_hash_no_pad::<H>(vec![
-        x.elements[0],
-        x.elements[1],
-        x.elements[2],
-        x.elements[3],
-        y.elements[0],
-        y.elements[1],
-        y.elements[2],
-        y.elements[3],
-    ])
+    builder.hash_n_to_hash_no_pad::<H>([x.elements, y.elements].concat())
+}
+
+pub fn poseidon_hash_pad<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    input: &[Target],
+) -> HashOutTarget {
+    let zero = builder.zero();
+    let one = builder.one();
+    let mut padded_input = input.to_vec();
+    padded_input.push(one);
+    while (padded_input.len() + 1) % SPONGE_WIDTH != 0 {
+        padded_input.push(zero);
+    }
+    padded_input.push(one);
+
+    builder.hash_n_to_hash_no_pad::<H>(padded_input)
 }

--- a/src/sparse_merkle_tree/gadgets/common.rs
+++ b/src/sparse_merkle_tree/gadgets/common.rs
@@ -8,22 +8,24 @@ use plonky2::{
     plonk::{circuit_builder::CircuitBuilder, config::AlgebraicHasher},
 };
 
-pub fn poseidon_two_to_one<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    x: HashOutTarget,
-    y: HashOutTarget,
-) -> HashOutTarget {
-    builder.hash_n_to_hash_no_pad::<H>(vec![
-        x.elements[0],
-        x.elements[1],
-        x.elements[2],
-        x.elements[3],
-        y.elements[0],
-        y.elements[1],
-        y.elements[2],
-        y.elements[3],
-    ])
-}
+use crate::poseidon::gadgets::poseidon_two_to_one;
+
+// pub fn poseidon_two_to_one<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>(
+//     builder: &mut CircuitBuilder<F, D>,
+//     x: HashOutTarget,
+//     y: HashOutTarget,
+// ) -> HashOutTarget {
+//     builder.hash_n_to_hash_no_pad::<H>(vec![
+//         x.elements[0],
+//         x.elements[1],
+//         x.elements[2],
+//         x.elements[3],
+//         y.elements[0],
+//         y.elements[1],
+//         y.elements[2],
+//         y.elements[3],
+//     ])
+// }
 
 #[test]
 fn test_calc_node_hash() {

--- a/src/zkdsa/account.rs
+++ b/src/zkdsa/account.rs
@@ -148,7 +148,7 @@ impl<F: Field> Address<F> {
 }
 
 pub fn private_key_to_public_key<F: RichField>(private_key: SecretKey<F>) -> PublicKey<F> {
-    PoseidonHash::two_to_one(private_key, private_key)
+    PoseidonHash::hash_pad(&private_key.elements)
 }
 
 pub fn public_key_to_address<F: RichField>(public_key: PublicKey<F>) -> Address<F> {

--- a/src/zkdsa/circuits/mod.rs
+++ b/src/zkdsa/circuits/mod.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::sparse_merkle_tree::goldilocks_poseidon::WrappedHashOut;
 
-use super::gadgets::signature::SimpleSignatureTarget;
+use super::{account::PublicKey, gadgets::signature::SimpleSignatureTarget};
 
 type C = PoseidonGoldilocksConfig;
 type H = <C as GenericConfig<D>>::InnerHasher;
@@ -54,7 +54,7 @@ pub struct SimpleSignatureCircuit<
 #[serde(bound = "")]
 pub struct SimpleSignaturePublicInputs<F: Field> {
     pub message: HashOut<F>,
-    pub public_key: HashOut<F>,
+    pub public_key: PublicKey<F>,
     pub signature: HashOut<F>,
 }
 

--- a/src/zkdsa/gadgets/account/mod.rs
+++ b/src/zkdsa/gadgets/account/mod.rs
@@ -5,7 +5,7 @@ use plonky2::{
     plonk::{circuit_builder::CircuitBuilder, config::AlgebraicHasher},
 };
 
-use crate::poseidon::gadgets::poseidon_two_to_one;
+use crate::poseidon::gadgets::poseidon_hash_pad;
 
 use super::super::account::Address;
 
@@ -46,5 +46,5 @@ pub fn private_key_to_public_key_target<
     builder: &mut CircuitBuilder<F, D>,
     private_key: HashOutTarget,
 ) -> HashOutTarget {
-    poseidon_two_to_one::<F, H, D>(builder, private_key, private_key)
+    poseidon_hash_pad::<F, H, D>(builder, &private_key.elements)
 }

--- a/src/zkdsa/gadgets/account/mod.rs
+++ b/src/zkdsa/gadgets/account/mod.rs
@@ -2,8 +2,10 @@ use plonky2::{
     field::{extension::Extendable, types::Field},
     hash::hash_types::{HashOutTarget, RichField},
     iop::{target::Target, witness::Witness},
-    plonk::circuit_builder::CircuitBuilder,
+    plonk::{circuit_builder::CircuitBuilder, config::AlgebraicHasher},
 };
+
+use crate::poseidon::gadgets::poseidon_two_to_one;
 
 use super::super::account::Address;
 
@@ -34,4 +36,15 @@ impl AddressTarget {
             ],
         })
     }
+}
+
+pub fn private_key_to_public_key_target<
+    F: RichField + Extendable<D>,
+    H: AlgebraicHasher<F>,
+    const D: usize,
+>(
+    builder: &mut CircuitBuilder<F, D>,
+    private_key: HashOutTarget,
+) -> HashOutTarget {
+    poseidon_two_to_one::<F, H, D>(builder, private_key, private_key)
 }

--- a/src/zkdsa/gadgets/signature/mod.rs
+++ b/src/zkdsa/gadgets/signature/mod.rs
@@ -7,7 +7,7 @@ use plonky2::{
 
 use crate::poseidon::gadgets::poseidon_two_to_one;
 
-use super::super::account::SecretKey;
+use super::{super::account::SecretKey, account::private_key_to_public_key_target};
 
 #[derive(Clone, Debug)]
 pub struct SimpleSignatureTarget {
@@ -51,7 +51,7 @@ pub fn sign_message_target<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, 
     private_key: HashOutTarget,
     message: HashOutTarget,
 ) -> (HashOutTarget, HashOutTarget) {
-    let public_key = poseidon_two_to_one::<F, H, D>(builder, private_key, private_key);
+    let public_key = private_key_to_public_key_target::<F, H, D>(builder, private_key);
     let signature = poseidon_two_to_one::<F, H, D>(builder, private_key, message);
 
     (signature, public_key)

--- a/src/zkdsa/gadgets/signature/mod.rs
+++ b/src/zkdsa/gadgets/signature/mod.rs
@@ -24,8 +24,7 @@ impl SimpleSignatureTarget {
         let private_key = builder.add_virtual_hash();
         let message = builder.add_virtual_hash();
 
-        let (signature, public_key) =
-            verify_simple_signature::<F, H, D>(builder, private_key, message);
+        let (signature, public_key) = sign_message_target::<F, H, D>(builder, private_key, message);
 
         Self {
             private_key,
@@ -47,11 +46,7 @@ impl SimpleSignatureTarget {
 }
 
 /// Returns `(signature, public_key)`
-pub fn verify_simple_signature<
-    F: RichField + Extendable<D>,
-    H: AlgebraicHasher<F>,
-    const D: usize,
->(
+pub fn sign_message_target<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     private_key: HashOutTarget,
     message: HashOutTarget,

--- a/src/zkdsa/mod.rs
+++ b/src/zkdsa/mod.rs
@@ -1,3 +1,4 @@
 pub mod account;
 pub mod circuits;
 pub mod gadgets;
+pub mod signature;

--- a/src/zkdsa/signature.rs
+++ b/src/zkdsa/signature.rs
@@ -1,0 +1,20 @@
+use plonky2::{
+    hash::{
+        hash_types::{HashOut, RichField},
+        poseidon::PoseidonHash,
+    },
+    plonk::config::Hasher,
+};
+
+use super::account::{private_key_to_public_key, PublicKey, SecretKey};
+
+/// Returns `(signature, public_key)`
+pub fn sign_message<F: RichField>(
+    private_key: SecretKey<F>,
+    message: HashOut<F>,
+) -> (HashOut<F>, PublicKey<F>) {
+    let public_key = private_key_to_public_key(private_key);
+    let signature = PoseidonHash::two_to_one(private_key, message);
+
+    (signature, public_key)
+}

--- a/src/zkdsa/signature.rs
+++ b/src/zkdsa/signature.rs
@@ -14,7 +14,7 @@ pub fn sign_message<F: RichField>(
     message: HashOut<F>,
 ) -> (HashOut<F>, PublicKey<F>) {
     let public_key = private_key_to_public_key(private_key);
-    let signature = PoseidonHash::two_to_one(private_key, message);
+    let signature = PoseidonHash::hash_pad(&[private_key.elements, message.elements].concat());
 
     (signature, public_key)
 }


### PR DESCRIPTION
public_key と signature の計算は異なる hash 関数を用いた方がよさそう.